### PR TITLE
Make compatible with Flashtalking upload check:

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -205,7 +205,7 @@ gulp.task('zip', ['build'], function () {
     for (var j=0, sl=sizes.length; j < sl; j++) {
       var size = sizes[j];
       var folder = 'dev/' + variant + '/' + size + '/';
-      var filename = pkg.meta.client + ' ' + pkg.meta.campaign + ' ' + variant + ' ' + size + ' v' + pkg.version + '.zip';
+      var filename = pkg.meta.client + '-' + pkg.meta.campaign + '-' + variant + '-' + size + '-v' + pkg.version + '.zip';
 
       //console.info(filename);
 

--- a/src/variants/flashtalking/300x250/manifest.js
+++ b/src/variants/flashtalking/300x250/manifest.js
@@ -1,6 +1,6 @@
 FT.manifest({
-  'filename': 'index.html',
-  'width':300,
-  'height':250,
-  'clickTagCount': 1
+  "filename": "index.html",
+  "width":300,
+  "height":250,
+  "clickTagCount": 1
 });


### PR DESCRIPTION
Changed single-quotes to double-quotes in the src/variants/flashtalking/manifest.js file.
Changed spaces to hyphen in the gulp zip task in the gulpfile.